### PR TITLE
Fixes Issue #4.

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -16,7 +16,7 @@ func applyPredicate(o *optionalImpl, funcValue reflect.Value) Optional {
 	valType := valValue.Type()
 	funcType := funcValue.Type()
 	// Checking whether element type is convertible to function's first argument's type.
-	if !valType.ConvertibleTo(funcType.In(0)) {
+	if !valType.AssignableTo(funcType.In(0)) {
 		panic("Predicate's argument is not compatible with this optional.")
 	}
 

--- a/filter_test.go
+++ b/filter_test.go
@@ -7,10 +7,10 @@ import (
 
 func TestOptionalImpl_Filter(t *testing.T) {
 	// Given
-	a := getOptional(1)
+	a := Of(1)
 	// When
-	b := a.Filter(func(a mockObject) bool {
-		return a.value == 1
+	b := a.Filter(func(i int) bool {
+		return i == 1
 	})
 	// Then
 	assert.True(t, b.IsPresent())
@@ -29,8 +29,8 @@ func TestOptionalImpl_Filter2(t *testing.T) {
 
 func TestOptionalImpl_Filter3(t *testing.T) {
 	// Given
-	optA := getOptional(1)
-	evilPredicate := func(a *mockObject) bool { return true }
+	optA := Of(1)
+	evilPredicate := func(i string) bool { return true }
 	// When
 	evilCall := func() {
 		optA.Filter(evilPredicate)
@@ -42,7 +42,7 @@ func TestOptionalImpl_Filter3(t *testing.T) {
 func TestOptionalImpl_Filter4(t *testing.T) {
 	// Given
 	a := getOptional(1)
-	evilPredicate := func(a mockObject) mockObject { return a }
+	evilPredicate := func(a int) int { return a }
 	// When
 	evilCall := func() {
 		a.Filter(evilPredicate) // Not a function

--- a/map.go
+++ b/map.go
@@ -31,7 +31,7 @@ func mapValue(o *optionalImpl, funcValue reflect.Value) Optional {
 	valType := valValue.Type()
 	funcType := funcValue.Type()
 	// Checking whether element type is convertible to function's first argument's type.
-	if !valType.ConvertibleTo(funcType.In(0)) {
+	if !valType.AssignableTo(funcType.In(0)) {
 		panic("Map function's argument is not compatible with this optional.")
 	}
 	result := funcValue.Call([]reflect.Value{valValue})[0]

--- a/map_test.go
+++ b/map_test.go
@@ -19,8 +19,8 @@ func TestOptionalImpl_Map(t *testing.T) {
 
 func TestOptionalImpl_Map2(t *testing.T) {
 	// Given
-	optA := getOptional(1)
-	evilMap := func(a *mockObject) *mockObject { return a }
+	optA := Of(1)
+	evilMap := func(a string) string { return a }
 	// When
 	evilCall := func() {
 		optA.Map(evilMap)


### PR DESCRIPTION
This makes the mapping and filter use the `AssignableTo` instead of
`ConvertableTo`.